### PR TITLE
Playbook should not fail if the pi host does not have a touchscreen

### DIFF
--- a/ansible/playbooks/init-setup.yml
+++ b/ansible/playbooks/init-setup.yml
@@ -47,6 +47,7 @@
       shell:
         cmd: dmesg | grep -i ft5406
       register: touchscreen_detect
+      ignore_errors: true
 
     - name: touchscreen setup
       block:


### PR DESCRIPTION
### Description of Changes
Playbook should not fail if the pi host does not have a touchscreen